### PR TITLE
initial configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,143 @@
+"use strict";
+
+module.exports = {
+  env: {
+    es6: true,
+    node: true,
+    browser: true
+  },
+  parser: "babel-eslint",
+  parserOptions: {
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true
+    },
+    sourceType: "module"
+  },
+  plugins: ["react", "import", "jsx-a11y"],
+  extends: ["wolox"],
+  globals: {
+    __DEV__: true
+  },
+  rules: {
+    "import/default": "error",
+    "import/export": "error",
+    "import/exports-last": "error",
+    "import/extensions": [
+      "error",
+      "never",
+      { js: "never", svg: "always", scss: "always" }
+    ],
+    "import/first": "error",
+    "import/named": "error",
+    "import/namespace": "error",
+    "import/newline-after-import": "error",
+    "import/no-absolute-path": "error",
+    "import/no-extraneous-dependencies": "error",
+    "import/no-mutable-exports": "error",
+    "import/no-named-as-default-member": "error",
+    "import/no-named-default": "error",
+    "import/no-self-import": "error",
+    "import/no-unresolved": "error",
+    "import/no-useless-path-segments": "error",
+    "import/no-webpack-loader-syntax": "error",
+    "import/order": ["error", { "newlines-between": "always" }],
+    "import/prefer-default-export": "off",
+    "jsx-a11y/anchor-is-valid": "error",
+    "react/boolean-prop-naming": "error",
+    "react/button-has-type": "error",
+    "react/default-props-match-prop-types": "error",
+    "react/destructuring-assignment": [
+      2,
+      "always",
+      { ignoreClassFields: true }
+    ],
+    "react/forbid-dom-props": ["error", { forbid: ["style", "id"] }],
+    "react/forbid-prop-types": "error",
+    "react/jsx-boolean-value": ["error", "never"],
+    "react/jsx-child-element-spacing": "error",
+    "react/jsx-closing-bracket-location": "error",
+    "react/jsx-closing-tag-location": "error",
+    "react/jsx-curly-brace-presence": [
+      "error",
+      { props: "never", children: "never" }
+    ],
+    "react/jsx-curly-spacing": "error",
+    "react/jsx-equals-spacing": "error",
+    "react/jsx-filename-extension": ["error", { extensions: [".js"] }],
+    "react/jsx-first-prop-new-line": "error",
+    "react/jsx-handler-names": "error",
+    "react/jsx-indent": ["error", 2],
+    "react/jsx-key": "error",
+    "react/jsx-max-depth": ["error", { max: 4 }],
+    "react/jsx-no-bind": "error",
+    "react/jsx-no-comment-textnodes": "error",
+    "react/jsx-no-duplicate-props": "error",
+    "react/jsx-no-target-blank": "error",
+    "react/jsx-one-expression-per-line": "error",
+    "react/jsx-pascal-case": "error",
+    "react/jsx-props-no-multi-spaces": "error",
+    "react/jsx-sort-default-props": "error",
+    "react/jsx-tag-spacing": ["error", { beforeClosing: "never" }],
+    "react/jsx-uses-vars": "error",
+    "react/jsx-wrap-multilines": [
+      "error",
+      {
+        declaration: "parens-new-line",
+        assignment: "parens-new-line",
+        return: "parens-new-line",
+        arrow: "parens-new-line",
+        condition: "parens-new-line",
+        logical: "parens-new-line",
+        prop: "parens-new-line"
+      }
+    ],
+    "react/forbid-foreign-prop-types": "error",
+    "react/no-access-state-in-setstate": "error",
+    "react/no-array-index-key": "error",
+    "react/no-children-prop": "error",
+    "react/no-danger": "error",
+    "react/no-deprecated": "error",
+    "react/no-did-mount-set-state": "error",
+    "react/no-did-update-set-state": "error",
+    "react/no-direct-mutation-state": "error",
+    "react/no-find-dom-node": "error",
+    "react/no-is-mounted": "error",
+    "react/no-multi-comp": "error",
+    "react/no-render-return-value": "error",
+    "react/no-typos": "error",
+    "react/no-string-refs": "error",
+    "react/no-this-in-sfc": "error",
+    "react/no-unescaped-entities": "error",
+    "react/no-unknown-property": "error",
+    "react/no-unsafe": "error",
+    "react/no-unused-prop-types": "error",
+    "react/no-unused-state": "error",
+    "react/no-will-update-set-state": "error",
+    "react/prefer-es6-class": "error",
+    "react/prefer-stateless-function": "error",
+    "react/prop-types": [2, { ignore: ["style", "children", "dispatch"] }],
+    "react/require-default-props": "off",
+    "react/react-in-jsx-scope": "error",
+    "react/require-render-return": "error",
+    "react/self-closing-comp": "error",
+    "react/sort-prop-types": [
+      "error",
+      {
+        ignoreCase: true,
+        callbacksLast: true,
+        requiredFirst: true,
+        sortShapeProp: true
+      }
+    ],
+    "react/style-prop-object": "error",
+    "react/void-dom-elements-no-children": "error"
+  },
+  settings: {
+    "import/resolver": {
+      node: {
+        extensions: [".js", ".android.js", ".ios.js"]
+      }
+    }
+  }
+};

--- a/index.js
+++ b/index.js
@@ -14,19 +14,20 @@ module.exports = {
     },
     sourceType: "module"
   },
-  plugins: ["react", "import", "jsx-a11y"],
+  plugins: ["react", "import", "jsx-a11y", "react-native"],
   extends: ["wolox"],
   globals: {
     __DEV__: true
   },
   rules: {
+    // Import
     "import/default": "error",
     "import/export": "error",
     "import/exports-last": "error",
     "import/extensions": [
       "error",
       "never",
-      { js: "never", svg: "always", scss: "always" }
+      { js: "never", svg: "always", scss: "always", png: "always", css: "always" }
     ],
     "import/first": "error",
     "import/named": "error",
@@ -43,15 +44,14 @@ module.exports = {
     "import/no-webpack-loader-syntax": "error",
     "import/order": ["error", { "newlines-between": "always" }],
     "import/prefer-default-export": "off",
+
+    // jsx-a11y
     "jsx-a11y/anchor-is-valid": "error",
+
+    // React
     "react/boolean-prop-naming": "error",
     "react/button-has-type": "error",
     "react/default-props-match-prop-types": "error",
-    "react/destructuring-assignment": [
-      2,
-      "always",
-      { ignoreClassFields: true }
-    ],
     "react/forbid-dom-props": ["error", { forbid: ["style", "id"] }],
     "react/forbid-prop-types": "error",
     "react/jsx-boolean-value": ["error", "never"],
@@ -132,6 +132,10 @@ module.exports = {
     ],
     "react/style-prop-object": "error",
     "react/void-dom-elements-no-children": "error"
+
+    // React Native
+    "no-colors-literals": "error",
+    "no-inline-styles": "error"
   },
   settings: {
     "import/resolver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wolox/eslint-config-react",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@wolox/eslint-config-react",
+  "version": "1.0.0",
+  "description": "Wolox's ESLint configuration for React projects ",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Wolox/eslint-config-wolox-react.git"
+  },
+  "keywords": [
+    "ESLint",
+    "React",
+    "Wolox"
+  ],
+  "author": "Damián Finkelstein <dfinkelstein@wolox.com.ar>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Wolox/eslint-config-wolox-react/issues"
+  },
+  "homepage": "https://github.com/Wolox/eslint-config-wolox-react#readme",
+  "peerDependencies": {
+    "eslint": "5.5.0",
+    "eslint-config-wolox": "2.0.0",
+    "eslint-plugin-flowtype": "^2.50.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsx-a11y": "^6.1.1",
+    "eslint-plugin-react": "^7.11.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config-wolox-react#readme",
   "peerDependencies": {
-    "eslint": "5.5.0",
+    "eslint": "^5.6.0",
     "eslint-config-wolox": "2.0.0",
     "eslint-plugin-flowtype": "^2.50.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react-native": "^3.3.0"
   }
 }


### PR DESCRIPTION
## Summary

Created a totally custom configuration for react. This configuration will extend from [eslint-config-wolox](https://github.com/Wolox/eslint-config-wolox), so I:

- Removed all eslint and prettier rules, which apply to Angular and Node too.
- Moved all import, react and jsx-a11y rules here, as they are specific to React.
- Removed all extensions but eslint-config-wolox, to make the rules explicit and totally custom
- Added import and react rules.

**Important**: This project can only be published after eslint-config-wolox is updated