### PR TITLE
Tested the config and fixed/changed some of the rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,29 @@ module.exports = {
     __DEV__: true
   },
   rules: {
+    // eslint-config-wolox overrides
+    "class-methods-use-this": [
+      "error",
+      {
+        exceptMethods: [
+          "render",
+          "getInitialState",
+          "getDefaultProps",
+          "componentWillMount",
+          "componentDidMount",
+          "componentWillReceiveProps",
+          "shouldComponentUpdate",
+          "componentWillUpdate",
+          "componentDidUpdate",
+          "componentWillUnmount",
+          "getSnapshotBeforeUpdate",
+          "UNSAFE_componentWillMount",
+          "UNSAFE_componentWillUpdate",
+          "UNSAFE_componentWillReceiveProps",
+        ]
+      }
+    ]
+
     // Import
     "import/default": "error",
     "import/export": "error",
@@ -27,7 +50,13 @@ module.exports = {
     "import/extensions": [
       "error",
       "never",
-      { js: "never", svg: "always", scss: "always", png: "always", css: "always" }
+      {
+        js: "never",
+        svg: "always",
+        scss: "always",
+        png: "always",
+        css: "always"
+      }
     ],
     "import/first": "error",
     "import/named": "error",
@@ -131,11 +160,11 @@ module.exports = {
       }
     ],
     "react/style-prop-object": "error",
-    "react/void-dom-elements-no-children": "error"
+    "react/void-dom-elements-no-children": "error",
 
     // React Native
-    "no-colors-literals": "error",
-    "no-inline-styles": "error"
+    "react-native/no-color-literals": "error",
+    "react-native/no-inline-styles": "error"
   },
   settings: {
     "import/resolver": {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ module.exports = {
   env: {
     es6: true,
     node: true,
-    browser: true
+    browser: true,
+    jest: true
   },
   parser: "babel-eslint",
   parserOptions: {
@@ -38,7 +39,7 @@ module.exports = {
           "getSnapshotBeforeUpdate",
           "UNSAFE_componentWillMount",
           "UNSAFE_componentWillUpdate",
-          "UNSAFE_componentWillReceiveProps",
+          "UNSAFE_componentWillReceiveProps"
         ]
       }
     ],
@@ -46,7 +47,6 @@ module.exports = {
     // Import
     "import/default": "error",
     "import/export": "error",
-    "import/exports-last": "error",
     "import/extensions": [
       "error",
       "never",
@@ -108,6 +108,7 @@ module.exports = {
     "react/jsx-props-no-multi-spaces": "error",
     "react/jsx-sort-default-props": "error",
     "react/jsx-tag-spacing": ["error", { beforeClosing: "never" }],
+    "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "react/jsx-wrap-multilines": [
       "error",

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
           "UNSAFE_componentWillReceiveProps",
         ]
       }
-    ]
+    ],
 
     // Import
     "import/default": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-config-wolox-react",
+  "version": "0.3.0",
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "@wolox/eslint-config-react",
-  "version": "1.0.0",
-  "lockfileVersion": 1
-}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
-  "name": "@wolox/eslint-config-react",
-  "version": "1.0.0",
+  "name": "eslint-config-wolox-react",
+  "version": "0.2.4",
   "description": "Wolox's ESLint configuration for React projects ",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Wolox/eslint-config-wolox-react.git"
@@ -23,7 +20,7 @@
   "homepage": "https://github.com/Wolox/eslint-config-wolox-react#readme",
   "peerDependencies": {
     "eslint": "^5.6.0",
-    "eslint-config-wolox": "2.0.0",
+    "eslint-config-wolox": "^2.0.0",
     "eslint-plugin-flowtype": "^2.50.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wolox-react",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Wolox's ESLint configuration for React projects ",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wolox-react",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Wolox's ESLint configuration for React projects ",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wolox-react",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Wolox's ESLint configuration for React projects ",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Summary

- Overrode `class-methods-use-this`. This rule shows an error if no `this` is not being used in the function, which makes sense. But for lifecycle methods, we may not need to use `this`. So all this methods are exceptions to the rule.
- Fixed react-native rules, which didn't have the correct prefix.