### PR TITLE
Removed rules added in wolox main config in the new version

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = {
     indent: "off",
     "no-mixed-operators": "off",
     "no-unused-expressions": "off",
+    "no-extra-parens": "off",
 
     // Babel
     "babel/no-unused-expressions": 1,
@@ -65,9 +66,7 @@ module.exports = {
       }
     ],
     "import/first": "error",
-    "import/named": "error",
     "import/namespace": "error",
-    "import/newline-after-import": "error",
     "import/no-absolute-path": "error",
     "import/no-extraneous-dependencies": "error",
     "import/no-mutable-exports": "error",
@@ -75,7 +74,6 @@ module.exports = {
     "import/no-named-default": "error",
     "import/no-self-import": "error",
     "import/no-unresolved": "error",
-    "import/no-useless-path-segments": "error",
     "import/no-webpack-loader-syntax": "error",
     "import/order": ["error", { "newlines-between": "always" }],
     "import/prefer-default-export": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wolox-react",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Wolox's ESLint configuration for React projects ",
   "main": "index.js",
   "repository": {
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/Wolox/eslint-config-wolox-react#readme",
   "peerDependencies": {
     "eslint": "^5.6.0",
-    "eslint-config-wolox": "^2.2.1",
+    "eslint-config-wolox": "^3.0.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.12.3",


### PR DESCRIPTION
## Summary

- Removed no-extra-parens as it conflicts with prettier sometimes
- Removed import rules added in the wolox main config in this PR: https://github.com/Wolox/eslint-config-wolox/pull/12/files
- Updated eslint-config-wolox version